### PR TITLE
Implement APS environment module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# react-native-aps-environment
+
+Tiny cross-platform React Native module that exposes the iOS `aps-environment` entitlement (`development` or `production`) and a handful of other build flags you can send to your backend. On Android sensible defaults are returned.
+
+> Use case: decide on the server whether to call `https://api.sandbox.push.apple.com` or `https://api.push.apple.com` for (VoIP) APNs by trusting what the signed app says.
+
+## Install
+
+```bash
+# Add to your app, pointing to YOUR Git URL
+npm i git+https://github.com/you/react-native-aps-environment.git
+# or
+yarn add git+https://github.com/you/react-native-aps-environment.git
+
+# iOS pods
+cd ios && pod install && cd -
+```
+
+No manual linking needed (autolinking works). Requires React Native 0.68+ (older likely fine, but untested).
+
+## API
+
+```ts
+import { getInfo, type AppEnvInfo } from 'react-native-aps-environment';
+
+const info: AppEnvInfo = await getInfo();
+// info = {
+//   build: 'debug' | 'release',
+//   isTestFlight: boolean,
+//   apsEnvironment: 'development' | 'production' | 'unknown',
+//   hasProvisioningProfile: boolean,
+//   jsDev: boolean,
+// }
+```
+
+Example usage when registering a VoIP token:
+
+```ts
+const info = await getInfo();
+VoipPushNotification.addEventListener('register', async (token) => {
+  await fetch('https://your.api/voip/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token, ...info }),
+  });
+});
+```
+
+On the server, switch APNs endpoint via `apsEnvironment`.
+
+## Troubleshooting
+
+- **Getting `BadDeviceToken` on prod APNs**: ensure the installed app is signed with a Distribution profile (Ad Hoc/TestFlight). In Xcode → Archives → select your build → **Show in Finder** → `Products/*.app` → inspect entitlements (should contain `aps-environment = production`).
+- **`Native module not found`**: run `pod install`, clean build folder, reinstall the app.
+- **Need ESM build**: the package ships CJS+types; if you want ESM, adjust `tsconfig` & `package.json` fields.
+
+## License
+
+MIT

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,28 @@
+buildscript {
+  ext {
+    kotlin_version = '1.8.22'
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace 'com.apsenv'
+  compileSdkVersion 34
+
+  defaultConfig {
+    minSdkVersion 23
+    targetSdkVersion 34
+  }
+
+  sourceSets {
+    main {
+      java.srcDirs = ["src/main/java"]
+    }
+  }
+}
+
+dependencies {
+  implementation 'com.facebook.react:react-native:+'
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.apsenv" />

--- a/android/src/main/java/com/apsenv/ApsEnvironmentModule.kt
+++ b/android/src/main/java/com/apsenv/ApsEnvironmentModule.kt
@@ -1,0 +1,23 @@
+package com.apsenv
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class ApsEnvironmentModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName() = "ApsEnvironment"
+
+  @ReactMethod
+  fun getInfo(promise: Promise) {
+    val map = Arguments.createMap().apply {
+      putString("build", "release")
+      putBoolean("isTestFlight", false)
+      putString("apsEnvironment", "unknown")
+      putBoolean("hasProvisioningProfile", false)
+    }
+
+    promise.resolve(map)
+  }
+}

--- a/ios/ApsEnvironment.m
+++ b/ios/ApsEnvironment.m
@@ -1,0 +1,6 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(ApsEnvironment, NSObject)
+RCT_EXTERN_METHOD(getInfo:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+@end

--- a/ios/ApsEnvironment.swift
+++ b/ios/ApsEnvironment.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Security
+import React
+
+@objc(ApsEnvironment)
+class ApsEnvironment: NSObject {
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func getInfo(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    #if DEBUG
+      let build = "debug"
+    #else
+      let build = "release"
+    #endif
+
+    let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+
+    var apsEnv = "unknown"
+    if let task = SecTaskCreateFromSelf(nil),
+       let val = SecTaskCopyValueForEntitlement(task, "aps-environment" as CFString, nil) as? String {
+      apsEnv = val
+    }
+
+    let hasProvisioning = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") != nil
+
+    resolve([
+      "build": build,
+      "isTestFlight": isTestFlight,
+      "apsEnvironment": apsEnv,
+      "hasProvisioningProfile": hasProvisioning
+    ])
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "react-native-aps-environment",
+  "version": "0.1.0",
+  "description": "Expose iOS aps-environment (development/production) to React Native",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "types": "lib/typescript/index.d.ts",
+  "react-native": "src/index.ts",
+  "files": [
+    "src/**/*",
+    "ios/**/*",
+    "android/**/*",
+    "react-native-aps-environment.podspec",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "react-native",
+    "ios",
+    "apns",
+    "aps-environment",
+    "voip",
+    "push"
+  ],
+  "author": "you",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": ">=17",
+    "react-native": ">=0.68"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/react-native-aps-environment.podspec
+++ b/react-native-aps-environment.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = 'react-native-aps-environment'
+  s.version      = '0.1.0'
+  s.summary      = 'Expose iOS aps-environment to React Native'
+  s.license      = { :type => 'MIT' }
+  s.authors      = { 'you' => 'you@example.com' }
+  s.homepage     = 'https://github.com/you/react-native-aps-environment'
+  s.source       = { :git => 'https://github.com/you/react-native-aps-environment.git', :tag => s.version.to_s }
+
+  s.platforms    = { :ios => '12.0' }
+  s.source_files = 'ios/**/*.{m,mm,swift}'
+  s.dependency   'React-Core'
+
+  s.swift_version = '5.0'
+end

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,48 @@
+import { NativeModules, Platform } from 'react-native';
+
+const LINKING_ERROR =
+  `The package 'react-native-aps-environment' doesn't seem to be linked.\n` +
+  Platform.select({ ios: "\n• Did you run 'pod install' in the ios/ directory?", default: '' });
+
+type ApsEnvNative = {
+  getInfo(): Promise<{
+    build: 'debug' | 'release';
+    isTestFlight: boolean;
+    apsEnvironment: 'development' | 'production' | 'unknown';
+    hasProvisioningProfile: boolean;
+  }>;
+};
+
+const Native: ApsEnvNative = NativeModules.ApsEnvironment
+  ? NativeModules.ApsEnvironment
+  : (new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    ) as any);
+
+export type AppEnvInfo = {
+  build: 'debug' | 'release';
+  isTestFlight: boolean;
+  apsEnvironment: 'development' | 'production' | 'unknown';
+  hasProvisioningProfile: boolean;
+  jsDev: boolean;
+};
+
+export async function getInfo(): Promise<AppEnvInfo> {
+  if (Platform.OS !== 'ios') {
+    return {
+      build: 'release',
+      isTestFlight: false,
+      apsEnvironment: 'unknown',
+      hasProvisioningProfile: false,
+      jsDev: __DEV__,
+    };
+  }
+
+  const native = await Native.getInfo();
+  return { ...native, jsDev: __DEV__ };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "lib/typescript",
+    "outDir": "lib/commonjs",
+    "target": "ES2019",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add the TypeScript surface that exposes app environment info from the native module
- implement the iOS Swift module that resolves aps entitlement data and bridge shim
- provide the Android stub module plus packaging metadata, podspec, and README documentation

## Testing
- not run (npm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68cb0b2361788324a7af0469e3af130c