### PR TITLE
Fix APS entitlement lookup for Swift

### DIFF
--- a/ios/ApsEnvironment.swift
+++ b/ios/ApsEnvironment.swift
@@ -2,6 +2,16 @@ import Foundation
 import Security
 import React
 
+@_silgen_name("SecTaskCreateFromSelf")
+private func SecTaskCreateFromSelfRaw(_ allocator: CFAllocator?) -> Unmanaged<CFTypeRef>?
+
+@_silgen_name("SecTaskCopyValueForEntitlement")
+private func SecTaskCopyValueForEntitlementRaw(
+  _ task: CFTypeRef,
+  _ entitlement: CFString,
+  _ error: UnsafeMutablePointer<Unmanaged<CFError>?>?
+) -> Unmanaged<CFTypeRef>?
+
 @objc(ApsEnvironment)
 class ApsEnvironment: NSObject {
   @objc static func requiresMainQueueSetup() -> Bool { false }
@@ -15,13 +25,10 @@ class ApsEnvironment: NSObject {
 
     let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
 
-    var apsEnv = "unknown"
-    if let task = SecTaskCreateFromSelf(nil),
-       let val = SecTaskCopyValueForEntitlement(task, "aps-environment" as CFString, nil) as? String {
-      apsEnv = val
-    }
-
-    let hasProvisioning = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") != nil
+    let provisioningURL = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision")
+    let fallbackApsEnv = provisioningURL.flatMap(readApsEnvironmentFromProvisioningProfile)
+    let apsEnv = readApsEnvironmentEntitlement() ?? fallbackApsEnv ?? "unknown"
+    let hasProvisioning = provisioningURL != nil
 
     resolve([
       "build": build,
@@ -29,5 +36,38 @@ class ApsEnvironment: NSObject {
       "apsEnvironment": apsEnv,
       "hasProvisioningProfile": hasProvisioning
     ])
+  }
+
+
+  private func readApsEnvironmentEntitlement() -> String? {
+    guard let task = SecTaskCreateFromSelfRaw(nil)?.takeRetainedValue() else { return nil }
+
+    guard let raw = SecTaskCopyValueForEntitlementRaw(task, "aps-environment" as CFString, nil)?.takeRetainedValue() else {
+      return nil
+    }
+
+    if let value = raw as? String {
+      return value
+    }
+
+    if CFGetTypeID(raw) == CFStringGetTypeID() {
+      return (raw as! CFString) as String
+    }
+
+    return nil
+  }
+
+
+  private func readApsEnvironmentFromProvisioningProfile(_ url: URL) -> String? {
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .ascii) else { return nil }
+
+    guard let keyRange = text.range(of: "<key>aps-environment</key>") else { return nil }
+    let searchStart = keyRange.upperBound..<text.endIndex
+
+    guard let open = text.range(of: "<string>", range: searchStart),
+          let close = text.range(of: "</string>", range: open.upperBound..<text.endIndex) else { return nil }
+
+    return String(text[open.upperBound..<close.lowerBound])
   }
 }


### PR DESCRIPTION
## Summary
- add Swift bindings for SecTask Security APIs so the module can read the aps-environment entitlement
- fall back to parsing the embedded provisioning profile when the entitlement lookup fails and reuse the URL for the hasProvisioning flag

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb0f02c9c483249612445296a86354